### PR TITLE
Wrap font option.src entries into a url() declaration when using observer

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function addUsingObserver(fontFamily, woffSrc, options) {
     return 'url(' + src + ')';
   })
 
-  addRuleToDocument(fontFaceRule(fontFamily, options));
+  addRuleToDocument(fontFaceRule(fontFamily, fontFaceOptions));
 
   return new FontFaceObserver(fontFamily, {weight: fontWeight}).check();
 }

--- a/index.js
+++ b/index.js
@@ -31,6 +31,20 @@ function addUsingFontFace(fontFamily, woffSrc) {
 function addUsingObserver(fontFamily, woffSrc, options) {
   var fontWeight = options['font-weight'] ? options['font-weight'] : 'normal';
 
+  // clone options object to avoid mutations
+  var fontFaceOptions = {};
+
+  for (option in options) {
+    if (options.hasOwnProperty(option)) {
+      fontFaceOptions[option] = options[option];
+    }
+  }
+
+  // wrap font src options entries into a "url()" declaration
+  fontFaceOptions.src = fontFaceOptions.src.map(function(src){
+    return 'url(' + src + ')';
+  })
+
   addRuleToDocument(fontFaceRule(fontFamily, options));
 
   return new FontFaceObserver(fontFamily, {weight: fontWeight}).check();


### PR DESCRIPTION
@font-face generation using observer is currently broken since it calls `font-face-rule` with a wrong `options.src` array.

`font-face-rule` currently receives an `options.src` which is an array of `src` string, while it expects an array of 'src' already wrapped into an `url()` declaration.

This PR clones the options object and iterates trough 'options.src' to replace the original urls.

### Current options.src passed to `font-face-rule` pkg
`["src1", "src2"]`

### Patched options.src
`["url(src1)", "url(src2)"]`